### PR TITLE
Table baking changes, tailored to [App]Table.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ $ composer require loadsys/cakephp-loadsys-theme:dev-master
 $ ./vendor/bin/cake bake all --theme LoadsysTheme name-of-thing
 ````
 
+This plugin does one other thing, `Table` Classes are baked to extend from a parent [App]Table class. The AppTable class it depends upon is provided from the [Loadsys CakePHP Skeleton](https://github.com/loadsys/CakePHP-Skeleton). Any Table Classes baked in which you wish to change this either bake using the default theme or modify the classes post baking.
+
 ## Contributing
 
 ### Reporting Issues

--- a/README.md
+++ b/README.md
@@ -11,17 +11,20 @@
 
 CakePHP 3.x bake generation theme that matches Loadsys' code sniffer standards.
 
+
 ## Requirements
+
+* CakePHP 3.x
+
 
 ## Installation
 
-### Composer
-
 ````bash
-$ composer require loadsys/cakephp-loadsys-theme:dev-master
+$ composer require --dev loadsys/cakephp-loadsys-theme:dev-master
 ````
 
-## Usage ##
+
+## Usage
 
 * Add this plugin to your application by adding this line to your bootstrap.php
 
@@ -29,7 +32,30 @@ $ composer require loadsys/cakephp-loadsys-theme:dev-master
 $ ./vendor/bin/cake bake all --theme LoadsysTheme name-of-thing
 ````
 
-This plugin does one other thing, `Table` Classes are baked to extend from a parent [App]Table class. The AppTable class it depends upon is provided from the [Loadsys CakePHP Skeleton](https://github.com/loadsys/CakePHP-Skeleton). Any Table Classes baked in which you wish to change this either bake using the default theme or modify the classes post baking.
+## Notable Changes
+
+### Tabs instead of spaces
+
+Loadsys has chosen to ignore the requirement of PSR-2 to use spaces for indenting. We've found tabs to be more convenient, and we're keeping them. If you disagree, that's fine-- this plugin isn't going to be much use to you.
+
+### K&R/1TBS Braces
+
+We're also sticking to [K&R style](https://en.wikipedia.org/wiki/Indent_style#K.26R_style) braces for everything.
+
+```php
+	public function foo() {
+		echo 'hi';
+	}
+```
+
+### AppTable
+
+The core team believes that using AppController and AppView continues to provide significant value to the framework ([thread](https://github.com/cakephp/cakephp/issues/4421#issuecomment-53759646)), but does not feel that hold true for AppTable (or AppEntity). We disagree.
+
+`Table` classes baked by this plugin extend from a parent [App]Table class (conveniently still called `Table` thanks to PHP namespaces.) The [Table](https://github.com/loadsys/CakePHP-Skeleton/tree/master/src/Model/Table/Table.php) class it depends upon is provided from the [Loadsys CakePHP Skeleton](https://github.com/loadsys/CakePHP-Skeleton). As in Cake 2, it's safe to completely ignore this file, provided it is at least present in your app. If you need a Table class baked in which you wish to change this, you must either bake using Cake's default theme or modify the classes after baking them.
+
+Additionally, because our `table.ctp` template assumes that our Skeleton's base Table class will be used, we suppress certain parts of the table baking process. The [App]Table class sets up the primary key, adds the Timestamp and CreatorModifier behaviors, defines two default associations to Creators and Modifiers in the Users table, and suppresses validation for the 5 related fields. It would therefore be redundant and defeat the purpose of the based Table class to bake tables that repeated these steps, so they are skipped.
+
 
 ## Contributing
 
@@ -40,6 +66,7 @@ Please use [GitHub Isuses](https://github.com/loadsys/CakePHP-LoadsysTheme/issue
 ### Development
 
 When developing this plugin, please fork and issue a PR for any new development.
+
 
 ## License ##
 

--- a/config/routes.php
+++ b/config/routes.php
@@ -2,5 +2,5 @@
 use Cake\Routing\Router;
 
 Router::plugin('LoadsysTheme', function ($routes) {
-    $routes->fallbacks('InflectedRoute');
+	$routes->fallbacks('InflectedRoute');
 });

--- a/src/Template/Bake/Element/Controller/add.ctp
+++ b/src/Template/Bake/Element/Controller/add.ctp
@@ -31,6 +31,7 @@ $compact = ["'" . $singularName . "'"];
 				$this->Flash->error(__('The <%= strtolower($singularHumanName) %> could not be saved. Please, try again.'));
 			}
 		}
+
 <%
 		$associations = array_merge(
 			$this->Bake->aliasExtractor($modelObj, 'BelongsTo'),

--- a/src/Template/Bake/Element/Controller/edit.ctp
+++ b/src/Template/Bake/Element/Controller/edit.ctp
@@ -38,6 +38,7 @@ $compact = ["'" . $singularName . "'"];
 				$this->Flash->error(__('The <%= strtolower($singularHumanName) %> could not be saved. Please, try again.'));
 			}
 		}
+
 <%
 		foreach (array_merge($belongsTo, $belongsToMany) as $assoc):
 			$association = $modelObj->association($assoc);

--- a/src/Template/Bake/Model/entity.ctp
+++ b/src/Template/Bake/Model/entity.ctp
@@ -42,7 +42,7 @@ class <%= $name %> extends Entity {
 	 *
 	 * @var array
 	 */
-	protected $_hidden = [<%= $this->Bake->stringifyList($hidden) %>];
+	protected $_hidden = [<%= str_replace('    ', "\t", $this->Bake->stringifyList($hidden)) %>];
 <% endif %>
 <% if (empty($fields) && empty($hidden)): %>
 

--- a/src/Template/Bake/Model/table.ctp
+++ b/src/Template/Bake/Model/table.ctp
@@ -71,7 +71,7 @@ class <%= $name %>Table extends Table {
 	$alias = $assoc['alias'];
 	unset($assoc['alias']);
 %>
-		$this-><%= $type %>('<%= $alias %>', [<%= $this->Bake->stringifyList($assoc, ['indent' => 3]) %>]);
+		$this-><%= $type %>('<%= $alias %>', [<%= str_replace('    ', "\t", $this->Bake->stringifyList($assoc, ['indent' => 3])) %>]);
 <% endforeach %>
 <% endforeach %>
 	}
@@ -90,7 +90,7 @@ class <%= $name %>Table extends Table {
 $firstField = true;
 foreach ($validation as $field => $rules):
 	if ($firstField !== true):
-		$validationMethods[] = "\n        \$validator";
+		$validationMethods[] = "\n\t\t\$validator";
 	endif;
 
 	foreach ($rules as $ruleName => $rule):
@@ -139,7 +139,7 @@ foreach ($validation as $field => $rules):
 	$validationMethods[] = array_pop($validationMethods) . ";";
 endforeach;
 %>
-<%= "            " . implode("\n            ", $validationMethods) %>
+<%= "\t\t\t" . implode("\n\t\t\t", $validationMethods) %>
 
 
 		return $validator;

--- a/src/Template/Bake/View/helper.ctp
+++ b/src/Template/Bake/View/helper.ctp
@@ -24,11 +24,11 @@ use Cake\View\View;
  */
 class <%= $name %>Helper extends Helper {
 
-    /**
-     * Default configuration.
-     *
-     * @var array
-     */
-    protected $_defaultConfig = [];
+	/**
+	 * Default configuration.
+	 *
+	 * @var array
+	 */
+	protected $_defaultConfig = [];
 
 }

--- a/src/Template/Bake/tests/fixture.ctp
+++ b/src/Template/Bake/tests/fixture.ctp
@@ -53,7 +53,7 @@ class <%= $name %>Fixture extends TestFixture {
 	 * @var array
 	 */
 	// @codingStandardsIgnoreStart
-	public $fields = <%= $schema %>;
+	public $fields = <%= str_replace('    ', "\t", $schema) %>;
 	// @codingStandardsIgnoreEnd
 <% endif; %>
 <% if ($records): %>
@@ -63,6 +63,6 @@ class <%= $name %>Fixture extends TestFixture {
 	 *
 	 * @var array
 	 */
-	public $records = <%= $records %>;
+	public $records = <%= str_replace('    ', "\t", $records) %>;
 <% endif; %>
 }

--- a/src/Template/Bake/tests/test_case.ctp
+++ b/src/Template/Bake/tests/test_case.ctp
@@ -47,7 +47,7 @@ class <%= $className %>Test extends TestCase {
 	 *
 	 * @var array
 	 */
-	public $fixtures = [<%= $this->Bake->stringifyList(array_values($fixtures)) %>];
+	public $fixtures = [<%= str_replace('    ', "\t", $this->Bake->stringifyList(array_values($fixtures))) %>];
 <% endif; %>
 <% if (!empty($construction)): %>
 


### PR DESCRIPTION
Baking a Table from the theme will produce a class that assumes a parent [App]Table is available. This is tailored to complement the `src/Model/Table/Table.php` that ships with the Loadsys Skeleton by suppressing "conventional" initialization code provided in that common parent class.

This includes using a UUID `id` field as the default primary key, and assuming that tables include created, modified, creator_id and modifier_id fields.
