### PR TITLE
F/sniff rollups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ Thumbs.db
 # Composer
 /vendor/*
 composer.lock
+
+/tmp

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# CakePHP-LoadsysTheme
+# Loadsys Bake Theme for CakePHP
 
 [![Latest Version](https://img.shields.io/github/release/loadsys/CakePHP-LoadsysTheme.svg?style=flat-square)](https://github.com/loadsys/CakePHP-LoadsysTheme/releases)
 [![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE.md)
@@ -9,7 +9,7 @@
 [![Coverage Status](https://coveralls.io/repos/loadsys/CakePHP-LoadsysTheme/badge.svg)](https://coveralls.io/r/loadsys/CakePHP-LoadsysTheme)
 -->
 
-CakePHP 3.x bake generation theme that matches Loadsys' code sniffer standards.
+A CakePHP 3.x bake generation theme that matches Loadsys' code sniffer standards. It's designed to dovetail with our [CakePHP App Skeleton](https://github.com/loadsys/CakePHP-Skeleton).
 
 
 ## Requirements
@@ -23,13 +23,15 @@ CakePHP 3.x bake generation theme that matches Loadsys' code sniffer standards.
 $ composer require loadsys/cakephp-loadsys-theme:~1.0
 ````
 
+_This plugin includes Bake in its own composer dependencies, so when using this theme you do not need to include it separately in your projects._
+
 
 ## Usage
 
 * Add this plugin to your application by adding this line to your bootstrap.php
 
 ````php
-CakePlugin::load('LoadsysTheme');
+CakePlugin::load('LoadsysTheme', ['bootstrap' => true, 'routes' => false]);
 ````
 
 * To use when baking, use the CLI option `--theme LoadsysTheme` like so
@@ -76,6 +78,11 @@ Please use [GitHub Isuses](https://github.com/loadsys/CakePHP-LoadsysTheme/issue
 ### Development
 
 When developing this plugin, please fork and issue a PR for any new development.
+
+### Running Tests
+
+* `vendor/bin/phpunit --coverage-html=tmp/coverage/`
+* `vendor/bin/phpcs`
 
 
 ## License ##

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
   "require": {
     "php": ">=5.4.16",
     "cakephp/cakephp": "~3.0",
+    "cakephp/bake": "~1.1",
     "loadsys/loadsys_codesniffer": "~3.0"
   },
   "require-dev": {

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -10,58 +10,17 @@ use Cake\Event\Event;
 use Cake\Event\EventManager;
 
 /**
- * Install our own BakeHelper.
+ * Default to the LoadsysTheme and install our own BakeHelper.
  */
 EventManager::instance()->on('Bake.initialize', function (Event $event) {
 	$view = $event->subject;
 
-	// Load our overridden BakeHelper class.
+	// Use the LoadsysTheme if none was explicitly named.
+	if (empty($view->theme())) {
+		$view->theme('LoadsysTheme');
+	}
+
+	// Swap in our overridden BakeHelper class.
 	$view->helpers()->unload('Bake');
 	$view->loadHelper('LoadsysTheme.Bake');
 });
-
-/**
- * Change viewVars globally.
- */
-// EventManager::instance()->on('Bake.beforeRender', function (Event $event) {
-//     $view = $event->subject;
-//
-//     // Use $rows for the main data variable in indexes
-//     if ($view->get('pluralName')) {
-//         $view->set('pluralName', 'rows');
-//     }
-//     if ($view->get('pluralVar')) {
-//         $view->set('pluralVar', 'rows');
-//     }
-//
-//     // Use $theOne for the main data variable in view/edit
-//     if ($view->get('singularName')) {
-//         $view->set('singularName', 'theOne');
-//     }
-//     if ($view->get('singularVar')) {
-//         $view->set('singularVar', 'theOne');
-//     }
-// });
-
-//
-/**
- * Example of injecting viewVars for a specific generated file:
- */
-// EventManager::instance()->on(
-//     'Bake.beforeRender.Controller.controller',
-//     function (Event $event) {
-//         $view = $event->subject();
-//         if ($view->viewVars['name'] == 'Users') {
-//             // add the login and logout actions to the Users controller
-//             $view->viewVars['actions'] = [
-//                 'login',
-//                 'logout',
-//                 'index',
-//                 'view',
-//                 'add',
-//                 'edit',
-//                 'delete'
-//             ];
-//         }
-//     }
-// );

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Hook into the normal baking process to install our own Helper(s) and
+ * modify the view Vars used for any generated file.
+ *
+ * @link http://book.cakephp.org/3.0/en/bake/development.html
+ */
+
+use Cake\Event\Event;
+use Cake\Event\EventManager;
+
+/**
+ * Install our own BakeHelper.
+ */
+EventManager::instance()->on('Bake.initialize', function (Event $event) {
+	$view = $event->subject;
+
+	// Load our overridden BakeHelper class.
+	$view->loadHelper('LoadsysTheme.Bake', []);
+});
+
+/**
+ * Change viewVars globally.
+ */
+// EventManager::instance()->on('Bake.beforeRender', function (Event $event) {
+//     $view = $event->subject;
+//
+//     // Use $rows for the main data variable in indexes
+//     if ($view->get('pluralName')) {
+//         $view->set('pluralName', 'rows');
+//     }
+//     if ($view->get('pluralVar')) {
+//         $view->set('pluralVar', 'rows');
+//     }
+//
+//     // Use $theOne for the main data variable in view/edit
+//     if ($view->get('singularName')) {
+//         $view->set('singularName', 'theOne');
+//     }
+//     if ($view->get('singularVar')) {
+//         $view->set('singularVar', 'theOne');
+//     }
+// });
+
+//
+/**
+ * Example of injecting viewVars for a specific generated file:
+ */
+// EventManager::instance()->on(
+//     'Bake.beforeRender.Controller.controller',
+//     function (Event $event) {
+//         $view = $event->subject();
+//         if ($view->viewVars['name'] == 'Users') {
+//             // add the login and logout actions to the Users controller
+//             $view->viewVars['actions'] = [
+//                 'login',
+//                 'logout',
+//                 'index',
+//                 'view',
+//                 'add',
+//                 'edit',
+//                 'delete'
+//             ];
+//         }
+//     }
+// );

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -16,7 +16,8 @@ EventManager::instance()->on('Bake.initialize', function (Event $event) {
 	$view = $event->subject;
 
 	// Load our overridden BakeHelper class.
-	$view->loadHelper('LoadsysTheme.Bake', []);
+	$view->helpers()->unload('Bake');
+	$view->loadHelper('LoadsysTheme.Bake');
 });
 
 /**

--- a/config/routes.php
+++ b/config/routes.php
@@ -1,6 +1,6 @@
 <?php
-use Cake\Routing\Router;
+/**
+ * Nothing to do currently.
+ */
 
-Router::plugin('LoadsysTheme', function ($routes) {
-	$routes->fallbacks('InflectedRoute');
-});
+use Cake\Routing\Router;

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<ruleset name="LoadsysTheme">
+	<description>Import rules from Loadsys standard.</description>
+
+	<arg value="sp"/>
+	<arg name="colors"/>
+
+	<!-- Include CakePHP rules (but don't USE them) and Loadsys rules. -->
+	<rule ref="vendor/cakephp/cakephp-codesniffer/CakePHP/ruleset.xml">
+		<exclude name="CakePHP"/>
+	</rule>
+ 	<rule ref="vendor/loadsys/loadsys_codesniffer/Loadsys/ruleset.xml" />
+
+	<file>./config</file>
+	<file>./src</file>
+	<file>./tests</file>
+</ruleset>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -4,7 +4,7 @@
     processIsolation="false"
     stopOnFailure="false"
     syntaxCheck="false"
-    bootstrap="./tests/bootstrap.php"
+    bootstrap="tests/bootstrap.php"
     >
     <php>
         <ini name="memory_limit" value="-1"/>
@@ -18,15 +18,8 @@
         </testsuite>
     </testsuites>
 
-    <!-- Setup a listener for fixtures -->
+    <!-- There is NO fixture listener! -->
     <listeners>
-        <listener
-        class="\Cake\TestSuite\Fixture\FixtureInjector"
-        file="./vendor/cakephp/cakephp/src/TestSuite/Fixture/FixtureInjector.php">
-            <arguments>
-                <object class="\Cake\TestSuite\Fixture\FixtureManager" />
-            </arguments>
-        </listener>
     </listeners>
 
     <!-- Prevent coverage reports from looking in tests and vendors -->

--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -4,7 +4,5 @@ namespace LoadsysTheme\Controller;
 
 use App\Controller\AppController as BaseController;
 
-class AppController extends BaseController
-{
-
+class AppController extends BaseController {
 }

--- a/src/Template/Bake/Controller/component.ctp
+++ b/src/Template/Bake/Controller/component.ctp
@@ -14,13 +14,16 @@
  */
 %>
 <?php
+/**
+ * <%= $name %> Component
+ */
 namespace <%= $namespace %>\Controller\Component;
 
 use Cake\Controller\Component;
 use Cake\Controller\ComponentRegistry;
 
 /**
- * <%= $name %> component
+ * \<%= $namespace %>\Controller\Component\<%= $name %>
  */
 class <%= $name %>Component extends Component {
 

--- a/src/Template/Bake/Controller/controller.ctp
+++ b/src/Template/Bake/Controller/controller.ctp
@@ -22,12 +22,15 @@ $defaultModel = $name;
 $ignoreAssociations = ['Creators', 'Modifiers'];
 %>
 <?php
+/**
+ * <%= $name %> Controller
+ */
 namespace <%= $namespace %>\Controller<%= $prefix %>;
 
 use <%= $namespace %>\Controller\AppController;
 
 /**
- * <%= $name %> Controller
+ * \<%= $namespace %>\Controller<%= $prefix %>\<%= $name %>
  *
  * @property \<%= $namespace %>\Model\Table\<%= $defaultModel %>Table $<%= $defaultModel %>
 <%

--- a/src/Template/Bake/Element/Controller/delete.ctp
+++ b/src/Template/Bake/Element/Controller/delete.ctp
@@ -29,5 +29,6 @@
 		} else {
 			$this->Flash->error(__('The <%= strtolower($singularHumanName) %> could not be deleted. Please, try again.'));
 		}
+
 		return $this->redirect(['action' => 'index']);
 	}

--- a/src/Template/Bake/Element/Controller/edit.ctp
+++ b/src/Template/Bake/Element/Controller/edit.ctp
@@ -27,7 +27,7 @@ $compact = ["'" . $singularName . "'"];
 	 */
 	public function edit($id = null) {
 		$<%= $singularName %> = $this-><%= $currentModelName %>->get($id, [
-			'contain' => [<%= $this->Bake->stringifyList($belongsToMany, ['indent' => false]) %>]
+			'contain' => [<%= $this->Bake->stringifyList($belongsToMany, ['indent' => false]) %>],
 		]);
 		if ($this->request->is(['patch', 'post', 'put'])) {
 			$<%= $singularName %> = $this-><%= $currentModelName %>->patchEntity($<%= $singularName %>, $this->request->data);

--- a/src/Template/Bake/Element/Controller/index.ctp
+++ b/src/Template/Bake/Element/Controller/index.ctp
@@ -24,7 +24,7 @@
 <% if ($belongsTo):
 	$belongsTo = array_diff($belongsTo, $ignoreAssociations); %>
 		$this->paginate = [
-			'contain' => [<%= $this->Bake->stringifyList($belongsTo, ['indent' => false]) %>]
+			'contain' => [<%= $this->Bake->stringifyList($belongsTo, ['indent' => false]) %>],
 		];
 <% endif; %>
 		$this->set('<%= $pluralName %>', $this->paginate($this-><%= $currentModelName %>));

--- a/src/Template/Bake/Element/Controller/view.ctp
+++ b/src/Template/Bake/Element/Controller/view.ctp
@@ -30,7 +30,7 @@ $allAssociations = array_merge(
 	 */
 	public function view($id = null) {
 		$<%= $singularName%> = $this-><%= $currentModelName %>->get($id, [
-			'contain' => [<%= $this->Bake->stringifyList($allAssociations, ['indent' => false]) %>]
+			'contain' => [<%= $this->Bake->stringifyList($allAssociations, ['indent' => false]) %>],
 		]);
 		$this->set('<%= $singularName %>', $<%= $singularName %>);
 		$this->set('_serialize', ['<%= $singularName %>']);

--- a/src/Template/Bake/Element/add-columns.ctp
+++ b/src/Template/Bake/Element/add-columns.ctp
@@ -1,0 +1,12 @@
+<% foreach ($columns as $columnName => $columnAttributes):
+$type = $columnAttributes['type'];
+unset($columnAttributes['type']);
+
+$columnAttributes = $this->Migration->getColumnOption($columnAttributes);
+$columnAttributes = $this->Migration->stringifyList($columnAttributes, ['indent' => 4]);
+if (!empty($columnAttributes)): %>
+            ->addColumn('<%= $columnName %>', '<%= $type %>', [<%= $columnAttributes %>])
+<% else: %>
+            ->addColumn('<%= $columnName %>', '<%= $type %>')
+<% endif; %>
+<% endforeach; %>

--- a/src/Template/Bake/Element/add-columns.ctp
+++ b/src/Template/Bake/Element/add-columns.ctp
@@ -5,8 +5,8 @@ unset($columnAttributes['type']);
 $columnAttributes = $this->Migration->getColumnOption($columnAttributes);
 $columnAttributes = $this->Migration->stringifyList($columnAttributes, ['indent' => 4]);
 if (!empty($columnAttributes)): %>
-            ->addColumn('<%= $columnName %>', '<%= $type %>', [<%= $columnAttributes %>])
+			->addColumn('<%= $columnName %>', '<%= $type %>', [<%= $columnAttributes %>])
 <% else: %>
-            ->addColumn('<%= $columnName %>', '<%= $type %>')
+			->addColumn('<%= $columnName %>', '<%= $type %>')
 <% endif; %>
 <% endforeach; %>

--- a/src/Template/Bake/Element/add-foreign-keys-from-create.ctp
+++ b/src/Template/Bake/Element/add-foreign-keys-from-create.ctp
@@ -1,0 +1,3 @@
+<% foreach ($constraints as $table => $tableConstraints):
+    echo $this->element('Migrations.add-foreign-keys', ['constraints' => $tableConstraints, 'table' => $table]);
+endforeach; %>

--- a/src/Template/Bake/Element/add-foreign-keys-from-create.ctp
+++ b/src/Template/Bake/Element/add-foreign-keys-from-create.ctp
@@ -1,3 +1,3 @@
 <% foreach ($constraints as $table => $tableConstraints):
-	echo $this->element('Migrations.add-foreign-keys', ['constraints' => $tableConstraints, 'table' => $table]);
+	echo $this->element('LoadsysTheme.add-foreign-keys', ['constraints' => $tableConstraints, 'table' => $table]);
 endforeach; %>

--- a/src/Template/Bake/Element/add-foreign-keys-from-create.ctp
+++ b/src/Template/Bake/Element/add-foreign-keys-from-create.ctp
@@ -1,3 +1,3 @@
 <% foreach ($constraints as $table => $tableConstraints):
-    echo $this->element('Migrations.add-foreign-keys', ['constraints' => $tableConstraints, 'table' => $table]);
+	echo $this->element('Migrations.add-foreign-keys', ['constraints' => $tableConstraints, 'table' => $table]);
 endforeach; %>

--- a/src/Template/Bake/Element/add-foreign-keys.ctp
+++ b/src/Template/Bake/Element/add-foreign-keys.ctp
@@ -1,0 +1,44 @@
+<%
+$statement = $this->Migration->tableStatement($table, true);
+$hasProcessedConstraint = false;
+%>
+<% foreach ($constraints as $constraint):
+    $constraintColumns = $constraint['columns'];
+    sort($constraintColumns);
+    if ($constraint['type'] !== 'unique'):
+        $hasProcessedConstraint = true;
+        $columnsList = '\'' . $constraint['columns'][0] . '\'';
+        if (count($constraint['columns']) > 1):
+            $columnsList = '[' . $this->Migration->stringifyList($constraint['columns'], ['indent' => 5]) . ']';
+        endif;
+        $this->Migration->returnedData['dropForeignKeys'][$table][] = $columnsList;
+
+        if (is_array($constraint['references'][1])):
+            $columnsReference = '[' . $this->Migration->stringifyList($constraint['references'][1], ['indent' => 5]) . ']';
+        else:
+            $columnsReference = '\'' . $constraint['references'][1] . '\'';
+        endif;
+
+        if (!isset($statement)):
+            $statement = $this->Migration->tableStatement($table);
+        endif;
+
+        if (!empty($statement)): %>
+
+        <%= $statement %>
+<% unset($statement);
+    endif; %>
+            ->addForeignKey(
+                <%= $columnsList %>,
+                '<%= $constraint['references'][0] %>',
+                <%= $columnsReference %>,
+                [
+                    'update' => '<%= strtoupper($constraint['update']) %>',
+                    'delete' => '<%= strtoupper($constraint['delete']) %>'
+                ]
+            )
+<% endif; %>
+<% endforeach; %>
+<% if (isset($this->Migration->tableStatements[$table]) && $hasProcessedConstraint): %>
+            ->update();
+<% endif; %>

--- a/src/Template/Bake/Element/add-foreign-keys.ctp
+++ b/src/Template/Bake/Element/add-foreign-keys.ctp
@@ -3,42 +3,42 @@ $statement = $this->Migration->tableStatement($table, true);
 $hasProcessedConstraint = false;
 %>
 <% foreach ($constraints as $constraint):
-    $constraintColumns = $constraint['columns'];
-    sort($constraintColumns);
-    if ($constraint['type'] !== 'unique'):
-        $hasProcessedConstraint = true;
-        $columnsList = '\'' . $constraint['columns'][0] . '\'';
-        if (count($constraint['columns']) > 1):
-            $columnsList = '[' . $this->Migration->stringifyList($constraint['columns'], ['indent' => 5]) . ']';
-        endif;
-        $this->Migration->returnedData['dropForeignKeys'][$table][] = $columnsList;
+	$constraintColumns = $constraint['columns'];
+	sort($constraintColumns);
+	if ($constraint['type'] !== 'unique'):
+		$hasProcessedConstraint = true;
+		$columnsList = '\'' . $constraint['columns'][0] . '\'';
+		if (count($constraint['columns']) > 1):
+			$columnsList = '[' . $this->Migration->stringifyList($constraint['columns'], ['indent' => 5]) . ']';
+		endif;
+		$this->Migration->returnedData['dropForeignKeys'][$table][] = $columnsList;
 
-        if (is_array($constraint['references'][1])):
-            $columnsReference = '[' . $this->Migration->stringifyList($constraint['references'][1], ['indent' => 5]) . ']';
-        else:
-            $columnsReference = '\'' . $constraint['references'][1] . '\'';
-        endif;
+		if (is_array($constraint['references'][1])):
+			$columnsReference = '[' . $this->Migration->stringifyList($constraint['references'][1], ['indent' => 5]) . ']';
+		else:
+			$columnsReference = '\'' . $constraint['references'][1] . '\'';
+		endif;
 
-        if (!isset($statement)):
-            $statement = $this->Migration->tableStatement($table);
-        endif;
+		if (!isset($statement)):
+			$statement = $this->Migration->tableStatement($table);
+		endif;
 
-        if (!empty($statement)): %>
+		if (!empty($statement)): %>
 
-        <%= $statement %>
+		<%= $statement %>
 <% unset($statement);
-    endif; %>
-            ->addForeignKey(
-                <%= $columnsList %>,
-                '<%= $constraint['references'][0] %>',
-                <%= $columnsReference %>,
-                [
-                    'update' => '<%= strtoupper($constraint['update']) %>',
-                    'delete' => '<%= strtoupper($constraint['delete']) %>'
-                ]
-            )
+	endif; %>
+			->addForeignKey(
+				<%= $columnsList %>,
+				'<%= $constraint['references'][0] %>',
+				<%= $columnsReference %>,
+				[
+					'update' => '<%= strtoupper($constraint['update']) %>',
+					'delete' => '<%= strtoupper($constraint['delete']) %>'
+				]
+			)
 <% endif; %>
 <% endforeach; %>
 <% if (isset($this->Migration->tableStatements[$table]) && $hasProcessedConstraint): %>
-            ->update();
+			->update();
 <% endif; %>

--- a/src/Template/Bake/Element/add-indexes.ctp
+++ b/src/Template/Bake/Element/add-indexes.ctp
@@ -1,0 +1,12 @@
+<% foreach ($indexes as $indexName => $index): %>
+            ->addIndex(
+                [<% echo $this->Migration->stringifyList($index['columns'], ['indent' => 5]); %>],
+                [<%
+                    $params = ['name' => $indexName];
+                    if ($index['type'] === 'unique'):
+                        $params['unique'] = true;
+                    endif;
+                    echo $this->Migration->stringifyList($params, ['indent' => 5]);
+                %>]
+            )
+<% endforeach; %>

--- a/src/Template/Bake/Element/add-indexes.ctp
+++ b/src/Template/Bake/Element/add-indexes.ctp
@@ -1,12 +1,9 @@
 <% foreach ($indexes as $indexName => $index): %>
-            ->addIndex(
-                [<% echo $this->Migration->stringifyList($index['columns'], ['indent' => 5]); %>],
-                [<%
-                    $params = ['name' => $indexName];
-                    if ($index['type'] === 'unique'):
-                        $params['unique'] = true;
-                    endif;
-                    echo $this->Migration->stringifyList($params, ['indent' => 5]);
-                %>]
-            )
+			->addIndex([<% echo $this->Migration->stringifyList($index['columns'], ['indent' => false]); %>], [<%
+				$params = ['name' => $indexName];
+				if ($index['type'] === 'unique'):
+					$params['unique'] = true;
+				endif;
+				echo $this->Migration->stringifyList($params, ['indent' => 4]);
+			%>])
 <% endforeach; %>

--- a/src/Template/Bake/Element/breadcrumbs.ctp
+++ b/src/Template/Bake/Element/breadcrumbs.ctp
@@ -14,27 +14,27 @@ $display = "\$$singularVar->{$displayField}";
 $keyedActions = ['view', 'edit'];
 
 switch ($action) {
-   case 'view':
-      $lastCrumb = "h({$display})";
-      break;
-   default:
-      $humanAction = Inflector::humanize($action);
-      $lastCrumb = "__('{$humanAction} {$singularHumanName}')";
-      break;
+	case 'view':
+		$lastCrumb = "h({$display})";
+		break;
+	default:
+		$humanAction = Inflector::humanize($action);
+		$lastCrumb = "__('{$humanAction} {$singularHumanName}')";
+		break;
 }
 %>
 <?php
 $this->set('breadcrumbs', [
-  __('<%= $pluralHumanName %>') => [
-	 'prefix' => $this->request->params['prefix'],
-	 'controller' => '<%= Inflector::camelize($pluralVar) %>',
-	 'action' => 'index',
-  ],
+	__('<%= $pluralHumanName %>') => [
+		'prefix' => $this->request->params['prefix'],
+		'controller' => '<%= Inflector::camelize($pluralVar) %>',
+		'action' => 'index',
+	],
 <% if ($action != "index"): %>
-  <%= $lastCrumb %> => [
-	 'prefix' => $this->request->params['prefix'],
-	 'controller' => '<%= Inflector::camelize($pluralVar) %>',
-	 'action' => '<%= $action %>',
+	<%= $lastCrumb %> => [
+		'prefix' => $this->request->params['prefix'],
+		'controller' => '<%= Inflector::camelize($pluralVar) %>',
+		'action' => '<%= $action %>',
 <%= (in_array($action, $keyedActions) ? "\t\t{$pk},\n" : '') %>    ],
 <% endif; %>
 ]);

--- a/src/Template/Bake/Element/create-tables.ctp
+++ b/src/Template/Bake/Element/create-tables.ctp
@@ -1,0 +1,80 @@
+<% foreach ($tables as $table => $schema):
+    $tableArgForMethods = $useSchema === true ? $schema : $table;
+    $tableArgForArray = $useSchema === true ? $table : $schema;
+
+$foreignKeys = [];
+$primaryKeysColumns = $this->Migration->primaryKeysColumnsList($tableArgForMethods);
+$primaryKeys = $this->Migration->primaryKeys($tableArgForMethods);
+$specialPk = (count($primaryKeys) > 1 || $primaryKeys[0]['name'] !== 'id' || $primaryKeys[0]['info']['columnType'] !== 'integer') && $autoId;
+%>
+<% if ($specialPk): %>
+
+        $this->table('<%= $tableArgForArray %>', ['id' => false, 'primary_key' => ['<%= implode("', '", \Cake\Utility\Hash::extract($primaryKeys, '{n}.name')) %>']])
+<% else: %>
+
+        $this->table('<%= $tableArgForArray %>')
+<% endif; %>
+<% if ($specialPk || !$autoId):
+    foreach ($primaryKeys as $primaryKey) :
+%>
+            ->addColumn('<%= $primaryKey['name'] %>', '<%= $primaryKey['info']['columnType'] %>', [<%
+            $columnOptions = $this->Migration->getColumnOption($primaryKey['info']['options']);
+            echo $this->Migration->stringifyList($columnOptions, ['indent' => 4]);
+            %>])
+<% endforeach; %>
+<% if (!$autoId): %>
+            ->addPrimaryKey(['<%= implode("', '", \Cake\Utility\Hash::extract($primaryKeys, '{n}.name')) %>'])
+<% endif; %>
+<% endif;
+foreach ($this->Migration->columns($tableArgForMethods) as $column => $config):
+%>
+            ->addColumn('<%= $column %>', '<%= $config['columnType'] %>', [<%
+            $columnOptions = $this->Migration->getColumnOption($config['options']);
+            if ($config['columnType'] === 'boolean' && isset($columnOptions['default']) && $this->Migration->value($columnOptions['default']) !== 'null'):
+                $columnOptions['default'] = (bool)$columnOptions['default'];
+            endif;
+            echo $this->Migration->stringifyList($columnOptions, ['indent' => 4]);
+            %>])
+<% endforeach;
+$tableConstraints = $this->Migration->constraints($tableArgForMethods);
+if (!empty($tableConstraints)):
+    sort($tableConstraints);
+    $constraints[$tableArgForArray] = $tableConstraints;
+
+    foreach ($constraints[$tableArgForArray] as $name => $constraint):
+        if ($constraint['type'] === 'foreign'):
+            $foreignKeys[] = $constraint['columns'];
+        endif;
+        if ($constraint['columns'] !== $primaryKeysColumns): %>
+            ->addIndex(
+                [<% echo $this->Migration->stringifyList($constraint['columns'], ['indent' => 5]); %>]<% echo ($constraint['type'] === 'unique') ? ',' : ''; %>
+
+<% if ($constraint['type'] === 'unique'): %>
+                ['unique' => true]
+<% endif; %>
+            )
+<% endif;
+    endforeach;
+endif;
+foreach($this->Migration->indexes($tableArgForMethods) as $index):
+    sort($foreignKeys);
+    $indexColumns = $index['columns'];
+    sort($indexColumns);
+    if (!in_array($indexColumns, $foreignKeys)):
+        %>
+            ->addIndex(
+                [<%
+                    echo $this->Migration->stringifyList($index['columns'], ['indent' => 5]);
+                %>]<% echo ($index['type'] === 'fulltext') ? ',' : ''; %>
+
+                <%- if ($index['type'] === 'fulltext'): %>
+                ['type' => 'fulltext']
+                <%- endif; %>
+            )
+<% endif;
+endforeach; %>
+            ->create();
+<% endforeach; %>
+<% if (!empty($constraints)): %>
+<% echo $this->element('Migrations.add-foreign-keys-from-create', ['constraints' => $constraints]); %>
+<% endif; %>

--- a/src/Template/Bake/Element/create-tables.ctp
+++ b/src/Template/Bake/Element/create-tables.ctp
@@ -9,10 +9,10 @@ $specialPk = (count($primaryKeys) > 1 || $primaryKeys[0]['name'] !== 'id' || $pr
 %>
 <% if ($specialPk): %>
 
-		$this->table('<%= $tableArgForArray %>', ['id' => false, 'primary_key' => ['<%= implode("', '", \Cake\Utility\Hash::extract($primaryKeys, '{n}.name')) %>']])
+		$this->table('<%= $tableArgForArray %>', ['id' => false, 'primary_key' => ['<%= implode("', '", \Cake\Utility\Hash::extract($primaryKeys, '{n}.name')) %>'], ['comment' => '']])
 <% else: %>
 
-		$this->table('<%= $tableArgForArray %>')
+		$this->table('<%= $tableArgForArray %>', ['comment' => ''])
 <% endif; %>
 <% if ($specialPk || !$autoId):
 	foreach ($primaryKeys as $primaryKey) :
@@ -30,6 +30,8 @@ foreach ($this->Migration->columns($tableArgForMethods) as $column => $config):
 %>
 			->addColumn('<%= $column %>', '<%= $config['columnType'] %>', [<%
 			$columnOptions = $this->Migration->getColumnOption($config['options']);
+			$columnOptions['comment'] = '';
+			//@TODO: init proper integrity checks matching MigrationsTest from skeleton. (Example: int id must be signed=false)
 			if ($config['columnType'] === 'boolean' && isset($columnOptions['default']) && $this->Migration->value($columnOptions['default']) !== 'null'):
 				$columnOptions['default'] = (bool)$columnOptions['default'];
 			endif;
@@ -76,5 +78,5 @@ endforeach; %>
 			->create();
 <% endforeach; %>
 <% if (!empty($constraints)): %>
-<% echo $this->element('Migrations.add-foreign-keys-from-create', ['constraints' => $constraints]); %>
+<% echo $this->element('LoadsysTheme.add-foreign-keys-from-create', ['constraints' => $constraints]); %>
 <% endif; %>

--- a/src/Template/Bake/Element/create-tables.ctp
+++ b/src/Template/Bake/Element/create-tables.ctp
@@ -1,6 +1,6 @@
 <% foreach ($tables as $table => $schema):
-    $tableArgForMethods = $useSchema === true ? $schema : $table;
-    $tableArgForArray = $useSchema === true ? $table : $schema;
+	$tableArgForMethods = $useSchema === true ? $schema : $table;
+	$tableArgForArray = $useSchema === true ? $table : $schema;
 
 $foreignKeys = [];
 $primaryKeysColumns = $this->Migration->primaryKeysColumnsList($tableArgForMethods);
@@ -9,71 +9,71 @@ $specialPk = (count($primaryKeys) > 1 || $primaryKeys[0]['name'] !== 'id' || $pr
 %>
 <% if ($specialPk): %>
 
-        $this->table('<%= $tableArgForArray %>', ['id' => false, 'primary_key' => ['<%= implode("', '", \Cake\Utility\Hash::extract($primaryKeys, '{n}.name')) %>']])
+		$this->table('<%= $tableArgForArray %>', ['id' => false, 'primary_key' => ['<%= implode("', '", \Cake\Utility\Hash::extract($primaryKeys, '{n}.name')) %>']])
 <% else: %>
 
-        $this->table('<%= $tableArgForArray %>')
+		$this->table('<%= $tableArgForArray %>')
 <% endif; %>
 <% if ($specialPk || !$autoId):
-    foreach ($primaryKeys as $primaryKey) :
+	foreach ($primaryKeys as $primaryKey) :
 %>
-            ->addColumn('<%= $primaryKey['name'] %>', '<%= $primaryKey['info']['columnType'] %>', [<%
-            $columnOptions = $this->Migration->getColumnOption($primaryKey['info']['options']);
-            echo $this->Migration->stringifyList($columnOptions, ['indent' => 4]);
-            %>])
+			->addColumn('<%= $primaryKey['name'] %>', '<%= $primaryKey['info']['columnType'] %>', [<%
+			$columnOptions = $this->Migration->getColumnOption($primaryKey['info']['options']);
+			echo $this->Migration->stringifyList($columnOptions, ['indent' => 4]);
+			%>])
 <% endforeach; %>
 <% if (!$autoId): %>
-            ->addPrimaryKey(['<%= implode("', '", \Cake\Utility\Hash::extract($primaryKeys, '{n}.name')) %>'])
+			->addPrimaryKey(['<%= implode("', '", \Cake\Utility\Hash::extract($primaryKeys, '{n}.name')) %>'])
 <% endif; %>
 <% endif;
 foreach ($this->Migration->columns($tableArgForMethods) as $column => $config):
 %>
-            ->addColumn('<%= $column %>', '<%= $config['columnType'] %>', [<%
-            $columnOptions = $this->Migration->getColumnOption($config['options']);
-            if ($config['columnType'] === 'boolean' && isset($columnOptions['default']) && $this->Migration->value($columnOptions['default']) !== 'null'):
-                $columnOptions['default'] = (bool)$columnOptions['default'];
-            endif;
-            echo $this->Migration->stringifyList($columnOptions, ['indent' => 4]);
-            %>])
+			->addColumn('<%= $column %>', '<%= $config['columnType'] %>', [<%
+			$columnOptions = $this->Migration->getColumnOption($config['options']);
+			if ($config['columnType'] === 'boolean' && isset($columnOptions['default']) && $this->Migration->value($columnOptions['default']) !== 'null'):
+				$columnOptions['default'] = (bool)$columnOptions['default'];
+			endif;
+			echo $this->Migration->stringifyList($columnOptions, ['indent' => 4]);
+			%>])
 <% endforeach;
 $tableConstraints = $this->Migration->constraints($tableArgForMethods);
 if (!empty($tableConstraints)):
-    sort($tableConstraints);
-    $constraints[$tableArgForArray] = $tableConstraints;
+	sort($tableConstraints);
+	$constraints[$tableArgForArray] = $tableConstraints;
 
-    foreach ($constraints[$tableArgForArray] as $name => $constraint):
-        if ($constraint['type'] === 'foreign'):
-            $foreignKeys[] = $constraint['columns'];
-        endif;
-        if ($constraint['columns'] !== $primaryKeysColumns): %>
-            ->addIndex(
-                [<% echo $this->Migration->stringifyList($constraint['columns'], ['indent' => 5]); %>]<% echo ($constraint['type'] === 'unique') ? ',' : ''; %>
+	foreach ($constraints[$tableArgForArray] as $name => $constraint):
+		if ($constraint['type'] === 'foreign'):
+			$foreignKeys[] = $constraint['columns'];
+		endif;
+		if ($constraint['columns'] !== $primaryKeysColumns): %>
+			->addIndex(
+				[<% echo $this->Migration->stringifyList($constraint['columns'], ['indent' => 5]); %>]<% echo ($constraint['type'] === 'unique') ? ',' : ''; %>
 
 <% if ($constraint['type'] === 'unique'): %>
-                ['unique' => true]
+				['unique' => true]
 <% endif; %>
-            )
+			)
 <% endif;
-    endforeach;
+	endforeach;
 endif;
 foreach($this->Migration->indexes($tableArgForMethods) as $index):
-    sort($foreignKeys);
-    $indexColumns = $index['columns'];
-    sort($indexColumns);
-    if (!in_array($indexColumns, $foreignKeys)):
-        %>
-            ->addIndex(
-                [<%
-                    echo $this->Migration->stringifyList($index['columns'], ['indent' => 5]);
-                %>]<% echo ($index['type'] === 'fulltext') ? ',' : ''; %>
+	sort($foreignKeys);
+	$indexColumns = $index['columns'];
+	sort($indexColumns);
+	if (!in_array($indexColumns, $foreignKeys)):
+		%>
+			->addIndex(
+				[<%
+					echo $this->Migration->stringifyList($index['columns'], ['indent' => 5]);
+				%>]<% echo ($index['type'] === 'fulltext') ? ',' : ''; %>
 
-                <%- if ($index['type'] === 'fulltext'): %>
-                ['type' => 'fulltext']
-                <%- endif; %>
-            )
+				<%- if ($index['type'] === 'fulltext'): %>
+				['type' => 'fulltext']
+				<%- endif; %>
+			)
 <% endif;
 endforeach; %>
-            ->create();
+			->create();
 <% endforeach; %>
 <% if (!empty($constraints)): %>
 <% echo $this->element('Migrations.add-foreign-keys-from-create', ['constraints' => $constraints]); %>

--- a/src/Template/Bake/Form/form.ctp
+++ b/src/Template/Bake/Form/form.ctp
@@ -14,6 +14,9 @@
 */
 %>
 <?php
+/**
+ * <%= $name %> Form
+ */
 namespace <%= $namespace %>\Form;
 
 use Cake\Form\Form;
@@ -21,7 +24,7 @@ use Cake\Form\Schema;
 use Cake\Validation\Validator;
 
 /**
- * <%= $name %> Form.
+ * \<%= $namespace %>\Form\<%= $name %>
  */
 class <%= $name %>Form extends Form {
 	/**

--- a/src/Template/Bake/Model/behavior.ctp
+++ b/src/Template/Bake/Model/behavior.ctp
@@ -14,13 +14,16 @@
  */
 %>
 <?php
+/**
+ * <%= $name %> Behavior
+ */
 namespace <%= $namespace %>\Model\Behavior;
 
 use Cake\ORM\Behavior;
 use Cake\ORM\Table;
 
 /**
- * <%= $name %> behavior
+ * \<%= $namespace %>\Model\Behavior\<%= $name %>
  */
 class <%= $name %>Behavior extends Behavior {
 

--- a/src/Template/Bake/Model/entity.ctp
+++ b/src/Template/Bake/Model/entity.ctp
@@ -42,7 +42,7 @@ class <%= $name %> extends Entity {
 	 *
 	 * @var array
 	 */
-	protected $_hidden = [<%= str_replace('    ', "\t", $this->Bake->stringifyList($hidden)) %>];
+	protected $_hidden = [<%= $this->Bake->stringifyList($hidden) %>];
 <% endif %>
 <% if (empty($fields) && empty($hidden)): %>
 

--- a/src/Template/Bake/Model/entity.ctp
+++ b/src/Template/Bake/Model/entity.ctp
@@ -14,12 +14,15 @@
  */
 %>
 <?php
+/**
+ * <%= $name %> Entity
+ */
 namespace <%= $namespace %>\Model\Entity;
 
 use Cake\ORM\Entity;
 
 /**
- * <%= $name %> Entity.
+ * \<%= $namespace %>\Model\Entity\<%= $name %>
  */
 class <%= $name %> extends Entity {
 <% if (!empty($fields)): %>

--- a/src/Template/Bake/Model/table.ctp
+++ b/src/Template/Bake/Model/table.ctp
@@ -97,7 +97,7 @@ class <%= $name %>Table extends Table {
 	$alias = $assoc['alias'];
 	unset($assoc['alias']);
 %>
-		$this-><%= $type %>('<%= $alias %>', [<%= str_replace('    ', "\t", $this->Bake->stringifyList($assoc, ['indent' => 3])) %>]);
+		$this-><%= $type %>('<%= $alias %>', [<%= $this->Bake->stringifyList($assoc, ['indent' => 3]) %>]);
 <% endforeach %>
 <% endforeach %>
 	}

--- a/src/Template/Bake/Model/table.ctp
+++ b/src/Template/Bake/Model/table.ctp
@@ -86,7 +86,6 @@ class <%= $name %>Table extends Table {
 		$this->primaryKey('<%= current((array)$primaryKey) %>');
 <% endif %>
 <% endif %>
-
 <% foreach ($behaviors as $behavior => $behaviorData):
 	if (in_array($behavior, $appTableBehaviors)) { continue; } %>
 		$this->addBehavior('<%= $behavior %>'<%= $behaviorData ? ", [" . implode(', ', $behaviorData) . ']' : '' %>);

--- a/src/Template/Bake/Model/table.ctp
+++ b/src/Template/Bake/Model/table.ctp
@@ -36,6 +36,9 @@ $appTableValidations = [
 ];
 %>
 <?php
+/**
+ * <%= $name %> Model
+ */
 namespace <%= $namespace %>\Model\Table;
 
 <%
@@ -52,7 +55,7 @@ echo implode("\n", $uses);
 
 
 /**
- * <%= $name %> Model
+ * \<%= $namespace %>\Model\Table\<%= $name %>
 <% if ($associations): %>
  *
 <% foreach ($associations as $type => $assocs): %>

--- a/src/Template/Bake/Plugin/config/routes.php.ctp
+++ b/src/Template/Bake/Plugin/config/routes.php.ctp
@@ -17,5 +17,5 @@
 use Cake\Routing\Router;
 
 Router::plugin('<%= $plugin %>', function ($routes) {
-	$routes->fallbacks('InflectedRoute');
+	$routes->fallbacks('DashedRoute');
 });

--- a/src/Template/Bake/Seed/seed.ctp
+++ b/src/Template/Bake/Seed/seed.ctp
@@ -1,0 +1,45 @@
+<%
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         0.1.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+%>
+<?php
+use Phinx\Seed\AbstractSeed;
+
+/**
+ * <%= $name %> seed.
+ */
+class <%= $name %>Seed extends AbstractSeed
+{
+    /**
+     * Run Method.
+     *
+     * Write your database seeder using this method.
+     *
+     * More information on writing seeders is available here:
+     * http://docs.phinx.org/en/latest/seeding.html
+     *
+     * @return void
+     */
+    public function run()
+    {
+<% if ($records): %>
+        $data = <%= $records %>;
+<% else: %>
+        $data = [];
+<% endif; %>
+
+        $table = $this->table('<%= $table %>');
+        $table->insert($data)->save();
+    }
+}

--- a/src/Template/Bake/Seed/seed.ctp
+++ b/src/Template/Bake/Seed/seed.ctp
@@ -14,32 +14,33 @@
  */
 %>
 <?php
-use Phinx\Seed\AbstractSeed;
-
 /**
  * <%= $name %> seed.
  */
-class <%= $name %>Seed extends AbstractSeed
-{
-    /**
-     * Run Method.
-     *
-     * Write your database seeder using this method.
-     *
-     * More information on writing seeders is available here:
-     * http://docs.phinx.org/en/latest/seeding.html
-     *
-     * @return void
-     */
-    public function run()
-    {
+use Phinx\Seed\AbstractSeed;
+
+/**
+ * \<%= $name %>
+ */
+class <%= $name %>Seed extends AbstractSeed {
+	/**
+	 * Run Method.
+	 *
+	 * Write your database seeder using this method.
+	 *
+	 * More information on writing seeders is available here:
+	 * http://docs.phinx.org/en/latest/seeding.html
+	 *
+	 * @return void
+	 */
+	public function run() {
 <% if ($records): %>
-        $data = <%= $records %>;
+		$data = <%= $records %>;
 <% else: %>
-        $data = [];
+		$data = [];
 <% endif; %>
 
-        $table = $this->table('<%= $table %>');
-        $table->insert($data)->save();
-    }
+		$table = $this->table('<%= $table %>');
+		$table->insert($data)->save();
+	}
 }

--- a/src/Template/Bake/Shell/shell.ctp
+++ b/src/Template/Bake/Shell/shell.ctp
@@ -14,12 +14,15 @@
  */
 %>
 <?php
+/**
+ * <%= $name %> Shell
+ */
 namespace <%= $namespace %>\Shell;
 
 use Cake\Console\Shell;
 
 /**
- * <%= $name %> shell command.
+ * \<%= $namespace %>\Shell\<%= $name %>
  */
 class <%= $name %>Shell extends Shell {
 

--- a/src/Template/Bake/View/cell.ctp
+++ b/src/Template/Bake/View/cell.ctp
@@ -14,12 +14,15 @@
  */
 %>
 <?php
+/**
+ * <%= $name %> Cell
+ */
 namespace <%= $namespace %>\View\Cell;
 
 use Cake\View\Cell;
 
 /**
- * <%= $name %> cell
+ * \<%= $namespace %>\View\Cell\<%= $name %>
  */
 class <%= $name %>Cell extends Cell {
 

--- a/src/Template/Bake/View/helper.ctp
+++ b/src/Template/Bake/View/helper.ctp
@@ -14,13 +14,16 @@
  */
 %>
 <?php
+/**
+ * <%= $name %> Helper
+ */
 namespace <%= $namespace %>\View\Helper;
 
 use Cake\View\Helper;
 use Cake\View\View;
 
 /**
- * <%= $name %> helper
+ * \<%= $namespace %>\View\Helper\<%= $name %>
  */
 class <%= $name %>Helper extends Helper {
 

--- a/src/Template/Bake/config/diff.ctp
+++ b/src/Template/Bake/config/diff.ctp
@@ -1,0 +1,214 @@
+<%
+/**
+* CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+* Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+*
+* Licensed under The MIT License
+* For full copyright and license information, please see the LICENSE.txt
+* Redistributions of files must retain the above copyright notice.
+*
+* @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+* @link          http://cakephp.org CakePHP(tm) Project
+* @since         3.0.0
+* @license       http://www.opensource.org/licenses/mit-license.php MIT License
+*/
+
+$tables = $data['fullTables'];
+unset($data['fullTables']);
+$constraints = [];
+
+$hasUnsignedPk = $this->Migration->hasUnsignedPrimaryKey($tables['add']);
+
+$autoId = true;
+if ($hasUnsignedPk) {
+    $autoId = false;
+}
+%>
+<?php
+use Migrations\AbstractMigration;
+
+class <%= $name %> extends AbstractMigration
+{
+    <%- if (!$autoId): %>
+
+    public $autoId = false;
+    <%- endif; %>
+
+    public function up()
+    {
+        <%- foreach ($data as $tableName => $tableDiff):
+            $hasRemoveFK = !empty($tableDiff['constraints']['remove']) || !empty($tableDiff['indexes']['remove']);
+        %>
+        <%- if ($hasRemoveFK): %>
+        $this->table('<%= $tableName %>')
+        <%- endif; %>
+            <%- if (!empty($tableDiff['constraints']['remove'])): %>
+            <%- foreach ($tableDiff['constraints']['remove'] as $constraintName => $constraintDefinition): %>
+            ->dropForeignKey([], '<%= $constraintName %>')
+            <%- endforeach; %>
+            <%- endif; %>
+            <%- if (!empty($tableDiff['indexes']['remove'])): %>
+            <%- foreach ($tableDiff['indexes']['remove'] as $indexName => $indexDefinition): %>
+            ->removeIndexByName('<%= $indexName %>')
+            <%- endforeach; %>
+            <%- endif; %>
+        <%- if ($hasRemoveFK): %>
+            ->update();
+
+        <%- endif; %>
+        <%- if (!empty($tableDiff['columns']['remove'])):
+            $statement = $this->Migration->tableStatement($tableName);
+            if (!empty($statement)): %>
+        <%= $statement %>
+            <%- endif; %>
+        <%- foreach ($tableDiff['columns']['remove'] as $columnName => $columnDefinition): %>
+            ->removeColumn('<%= $columnName %>')
+        <%- endforeach; %>
+        <%- endif; %>
+        <%- if (!empty($tableDiff['columns']['changed'])):
+            $statement = $this->Migration->tableStatement($tableName);
+            if (!empty($statement)): %>
+        <%= $statement %>
+            <%- endif; %>
+        <%- foreach ($tableDiff['columns']['changed'] as $columnName => $columnAttributes):
+            $type = $columnAttributes['type'];
+            unset($columnAttributes['type']);
+            $columnAttributes = $this->Migration->getColumnOption($columnAttributes);
+            $columnAttributes = $this->Migration->stringifyList($columnAttributes, ['indent' => 4]);
+            if (!empty($columnAttributes)): %>
+            ->changeColumn('<%= $columnName %>', '<%= $type %>', [<%= $columnAttributes %>])
+            <%- else: %>
+            ->changeColumn('<%= $columnName %>', '<%= $type %>')
+            <%- endif; %>
+        <%- endforeach;
+            if (isset($this->Migration->tableStatements[$tableName])): %>
+            ->update();
+            <%- endif; %>
+        <%- endif; %>
+        <%- endforeach; %>
+        <%- if (!empty($tables['add'])): %>
+                <%- echo $this->element('Migrations.create-tables', ['tables' => $tables['add'], 'autoId' => $autoId, 'useSchema' => true]) %>
+        <%- endif; %>
+        <%- foreach ($data as $tableName => $tableDiff): %>
+            <%- if (!empty($tableDiff['columns']['add'])):
+            $statement = $this->Migration->tableStatement($tableName, true);
+            if (!empty($statement)): %>
+
+        <%= $statement %>
+            <%- endif; %>
+            <%- echo $this->element('Migrations.add-columns', ['columns' => $tableDiff['columns']['add']]) %>
+            <%- endif; %>
+            <%- if (!empty($tableDiff['indexes']['add'])):
+            $statement = $this->Migration->tableStatement($tableName);
+            if (!empty($statement)): %>
+        <%= $statement %>
+            <%- endif; %>
+            <%- echo $this->element('Migrations.add-indexes', ['indexes' => $tableDiff['indexes']['add']]) %>
+            <%- endif;
+            if (isset($this->Migration->tableStatements[$tableName])): %>
+            ->update();
+            <%- endif; %>
+        <%- endforeach; %>
+        <%- foreach ($data as $tableName => $tableDiff): %>
+        <%- if (!empty($tableDiff['constraints']['add'])): %>
+            <%- echo $this->element(
+                'Migrations.add-foreign-keys',
+                ['constraints' => $tableDiff['constraints']['add'], 'table' => $tableName]
+            ); %>
+            <%- endif; %>
+        <%- endforeach; %>
+
+        <%- if (!empty($tables['remove'])): %>
+        <%- foreach ($tables['remove'] as $tableName => $table): %>
+        $this->dropTable('<%= $tableName %>');
+            <%- endforeach; %>
+        <%- endif; %>
+    }
+
+    public function down()
+    {
+        <%- $constraints = [];
+        $emptyLine = false;
+        if (!empty($this->Migration->returnedData['dropForeignKeys'])):
+            foreach ($this->Migration->returnedData['dropForeignKeys'] as $table => $columnsList):
+                $maxKey = count($columnsList) - 1;
+                if ($emptyLine === true): %>
+
+                <%- else:
+                    $emptyLine = true;
+                endif; %>
+        $this->table('<%= $table %>')
+                <%- foreach ($columnsList as $key => $columns): %>
+            ->dropForeignKey(
+                <%= $columns %>
+            )<%= ($key === $maxKey) ? ';' : '' %>
+                <%- endforeach; %>
+            <%- endforeach; %>
+        <%- endif; %>
+        <%- if (!empty($tables['remove'])): %>
+            <%- echo $this->element('Migrations.create-tables', ['tables' => $tables['remove'], 'autoId' => $autoId, 'useSchema' => true]) %>
+        <%- endif; %>
+        <%- foreach ($data as $tableName => $tableDiff): %>
+            <%- if (!empty($tableDiff['indexes']['add'])): %>
+
+        $this->table('<%= $tableName %>')
+                <%- foreach ($tableDiff['indexes']['add'] as $indexName => $index): %>
+            ->removeIndexByName('<%= $indexName %>')
+                <%- endforeach %>
+            ->update();
+            <%- endif; %>
+        <%- if (!empty($tableDiff['columns']['remove']) ||
+            !empty($tableDiff['columns']['changed']) ||
+            !empty($tableDiff['columns']['add']) ||
+            !empty($tableDiff['indexes']['remove'])
+        ): %>
+
+        <%= $this->Migration->tableStatement($tableName, true) %>
+        <%- endif; %>
+        <%- if (!empty($tableDiff['columns']['remove'])): %>
+        <%- echo $this->element('Migrations.add-columns', ['columns' => $tableDiff['columns']['remove']]) %>
+        <%- endif; %>
+        <%- if (!empty($tableDiff['columns']['changed'])):
+            $oldTableDef = $dumpSchema[$tableName];
+            foreach ($tableDiff['columns']['changed'] as $columnName => $columnAttributes):
+            $columnAttributes = $oldTableDef->column($columnName);
+            $type = $columnAttributes['type'];
+            unset($columnAttributes['type']);
+            $columnAttributes = $this->Migration->getColumnOption($columnAttributes);
+            $columnAttributes = $this->Migration->stringifyList($columnAttributes, ['indent' => 4]);
+            if (!empty($columnAttributes)): %>
+            ->changeColumn('<%= $columnName %>', '<%= $type %>', [<%= $columnAttributes %>])
+            <%- else: %>
+            ->changeColumn('<%= $columnName %>', '<%= $type %>')
+            <%- endif; %>
+            <%- endforeach; %>
+        <%- endif; %>
+        <%- if (!empty($tableDiff['columns']['add'])): %>
+            <%- foreach ($tableDiff['columns']['add'] as $columnName => $columnAttributes): %>
+            ->removeColumn('<%= $columnName %>')
+            <%- endforeach; %>
+        <%- endif; %>
+            <%- if (!empty($tableDiff['indexes']['remove'])): %>
+            <%- echo $this->element('Migrations.add-indexes', ['indexes' => $tableDiff['indexes']['remove']]) %>
+            <%- endif;
+            if (isset($this->Migration->tableStatements[$tableName])): %>
+            ->update();
+            <%- endif; %>
+        <%- endforeach; %>
+        <%- foreach ($data as $tableName => $tableDiff): %>
+            <%- if (!empty($tableDiff['constraints']['remove'])): %>
+                <%- echo $this->element(
+                    'Migrations.add-foreign-keys',
+                    ['constraints' => $tableDiff['constraints']['remove'], 'table' => $tableName]
+                ); %>
+            <%- endif; %>
+        <%- endforeach; %>
+        <%- if (!empty($tables['add'])): %>
+            <%- foreach ($tables['add'] as $tableName => $table): %>
+
+        $this->dropTable('<%= $tableName %>');
+            <%- endforeach; %>
+        <%- endif; %>
+    }
+}
+

--- a/src/Template/Bake/config/diff.ctp
+++ b/src/Template/Bake/config/diff.ctp
@@ -104,7 +104,7 @@ class <%= $name %> extends AbstractMigration {
         <%- endif; %>
         <%- endforeach; %>
         <%- if (!empty($tables['add'])): %>
-                <%- echo $this->element('Migrations.create-tables', ['tables' => $tables['add'], 'autoId' => $autoId, 'useSchema' => true]) %>
+                <%- echo $this->element('LoadsysTheme.create-tables', ['tables' => $tables['add'], 'autoId' => $autoId, 'useSchema' => true]) %>
         <%- endif; %>
         <%- foreach ($data as $tableName => $tableDiff): %>
             <%- if (!empty($tableDiff['columns']['add'])):
@@ -113,14 +113,14 @@ class <%= $name %> extends AbstractMigration {
 
         <%= $statement %>
             <%- endif; %>
-            <%- echo $this->element('Migrations.add-columns', ['columns' => $tableDiff['columns']['add']]) %>
+            <%- echo $this->element('LoadsysTheme.add-columns', ['columns' => $tableDiff['columns']['add']]) %>
             <%- endif; %>
             <%- if (!empty($tableDiff['indexes']['add'])):
             $statement = $this->Migration->tableStatement($tableName);
             if (!empty($statement)): %>
         <%= $statement %>
             <%- endif; %>
-            <%- echo $this->element('Migrations.add-indexes', ['indexes' => $tableDiff['indexes']['add']]) %>
+            <%- echo $this->element('LoadsysTheme.add-indexes', ['indexes' => $tableDiff['indexes']['add']]) %>
             <%- endif;
             if (isset($this->Migration->tableStatements[$tableName])): %>
             ->update();
@@ -170,7 +170,7 @@ class <%= $name %> extends AbstractMigration {
             <%- endforeach; %>
         <%- endif; %>
         <%- if (!empty($tables['remove'])): %>
-            <%- echo $this->element('Migrations.create-tables', ['tables' => $tables['remove'], 'autoId' => $autoId, 'useSchema' => true]) %>
+            <%- echo $this->element('LoadsysTheme.create-tables', ['tables' => $tables['remove'], 'autoId' => $autoId, 'useSchema' => true]) %>
         <%- endif; %>
         <%- foreach ($data as $tableName => $tableDiff): %>
             <%- if (!empty($tableDiff['indexes']['add'])): %>
@@ -190,7 +190,7 @@ class <%= $name %> extends AbstractMigration {
         <%= $this->Migration->tableStatement($tableName, true) %>
         <%- endif; %>
         <%- if (!empty($tableDiff['columns']['remove'])): %>
-        <%- echo $this->element('Migrations.add-columns', ['columns' => $tableDiff['columns']['remove']]) %>
+        <%- echo $this->element('LoadsysTheme.add-columns', ['columns' => $tableDiff['columns']['remove']]) %>
         <%- endif; %>
         <%- if (!empty($tableDiff['columns']['changed'])):
             $oldTableDef = $dumpSchema[$tableName];
@@ -213,7 +213,7 @@ class <%= $name %> extends AbstractMigration {
             <%- endforeach; %>
         <%- endif; %>
             <%- if (!empty($tableDiff['indexes']['remove'])): %>
-            <%- echo $this->element('Migrations.add-indexes', ['indexes' => $tableDiff['indexes']['remove']]) %>
+            <%- echo $this->element('LoadsysTheme.add-indexes', ['indexes' => $tableDiff['indexes']['remove']]) %>
             <%- endif;
             if (isset($this->Migration->tableStatements[$tableName])): %>
             ->update();

--- a/src/Template/Bake/config/diff.ctp
+++ b/src/Template/Bake/config/diff.ctp
@@ -25,17 +25,34 @@ if ($hasUnsignedPk) {
 }
 %>
 <?php
+/**
+ * <%= $name %> Migration
+ */
 use Migrations\AbstractMigration;
 
-class <%= $name %> extends AbstractMigration
-{
+/**
+ * \<%= $name %>
+ */
+class <%= $name %> extends AbstractMigration {
     <%- if (!$autoId): %>
 
+	/**
+	 * Auto ID.
+	 *
+	 * @var bool
+	 */
     public $autoId = false;
     <%- endif; %>
 
-    public function up()
-    {
+	/**
+	 * Up Method.
+	 *
+	 * More information on this method is available here:
+	 * http://docs.phinx.org/en/latest/migrations.html#the-up-method
+	 *
+	 * @return void
+	 */
+    public function up() {
         <%- foreach ($data as $tableName => $tableDiff):
             $hasRemoveFK = !empty($tableDiff['constraints']['remove']) || !empty($tableDiff['indexes']['remove']);
         %>
@@ -125,8 +142,15 @@ class <%= $name %> extends AbstractMigration
         <%- endif; %>
     }
 
-    public function down()
-    {
+	/**
+	 * Down Method.
+	 *
+	 * More information on this method is available here:
+	 * http://docs.phinx.org/en/latest/migrations.html#the-down-method
+	 *
+	 * @return void
+	 */
+    public function down() {
         <%- $constraints = [];
         $emptyLine = false;
         if (!empty($this->Migration->returnedData['dropForeignKeys'])):

--- a/src/Template/Bake/config/skeleton.ctp
+++ b/src/Template/Bake/config/skeleton.ctp
@@ -1,0 +1,79 @@
+<%
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.0.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+
+$wantedOptions = array_flip(['length', 'limit', 'default', 'unsigned', 'null', 'comment', 'autoIncrement']);
+$tableMethod = $this->Migration->tableMethod($action);
+$columnMethod = $this->Migration->columnMethod($action);
+$indexMethod = $this->Migration->indexMethod($action);
+%>
+<?php
+use Migrations\AbstractMigration;
+
+class <%= $name %> extends AbstractMigration
+{
+    <%- if ($tableMethod === 'create' && !empty($columns['primaryKey'])): %>
+
+    public $autoId = false;
+
+    <%- endif; %>
+    /**
+     * Change Method.
+     *
+     * More information on this method is available here:
+     * http://docs.phinx.org/en/latest/migrations.html#the-change-method
+     * @return void
+     */
+    public function change()
+    {
+<% foreach ($tables as $table): %>
+        $table = $this->table('<%= $table%>');
+<% if ($tableMethod !== 'drop') : %>
+<% if ($columnMethod === 'removeColumn'): %>
+<% foreach ($columns['fields'] as $column => $config): %>
+        <%= "\$table->$columnMethod('" . $column . "');"; %>
+<% endforeach; %>
+<% foreach ($columns['indexes'] as $column => $config): %>
+        <%= "\$table->$indexMethod([" . $this->Migration->stringifyList($config['columns']) . ");"; %>
+<% endforeach; %>
+<% else : %>
+<% foreach ($columns['fields'] as $column => $config): %>
+        $table-><%= $columnMethod %>('<%= $column %>', '<%= $config['columnType'] %>', [<%
+                $columnOptions = $config['options'];
+                $columnOptions = array_intersect_key($columnOptions, $wantedOptions);
+                if (empty($columnOptions['comment'])) {
+                    unset($columnOptions['comment']);
+                }
+                echo $this->Migration->stringifyList($columnOptions, ['indent' => 3]);
+            %>]);
+<% endforeach; %>
+<% foreach ($columns['indexes'] as $column => $config): %>
+        $table-><%= $indexMethod %>([<%=
+                $this->Migration->stringifyList($config['columns'], ['indent' => 3])
+                %>], [<%
+                $options = [];
+                echo $this->Migration->stringifyList($config['options'], ['indent' => 3]);
+            %>]);
+<% endforeach; %>
+<% if ($tableMethod === 'create' && !empty($columns['primaryKey'])): %>
+        $table->addPrimaryKey([<%=
+                $this->Migration->stringifyList($columns['primaryKey'], ['indent' => 3])
+                %>]);
+<% endif; %>
+<% endif; %>
+<% endif; %>
+        $table-><%= $tableMethod %>();
+<% endforeach; %>
+    }
+}

--- a/src/Template/Bake/config/skeleton.ctp
+++ b/src/Template/Bake/config/skeleton.ctp
@@ -54,30 +54,27 @@ class <%= $name %> extends AbstractMigration {
 		<%= "\$table->$columnMethod('" . $column . "');"; %>
 <% endforeach; %>
 <% foreach ($columns['indexes'] as $column => $config): %>
-		<%= "\$table->$indexMethod([" . $this->Migration->stringifyList($config['columns']) . ");"; %>
+		<%= "\$table->$indexMethod([" . $this->Bake->stringifyList($config['columns']) . ");"; %>
 <% endforeach; %>
 <% else : %>
 <% foreach ($columns['fields'] as $column => $config): %>
 		$table-><%= $columnMethod %>('<%= $column %>', '<%= $config['columnType'] %>', [<%
 				$columnOptions = $config['options'];
 				$columnOptions = array_intersect_key($columnOptions, $wantedOptions);
-				if (empty($columnOptions['comment'])) {
-					unset($columnOptions['comment']);
-				}
-				echo $this->Migration->stringifyList($columnOptions, ['indent' => 3]);
+				echo $this->Bake->stringifyList($columnOptions, ['indent' => 3]);
 			%>]);
 <% endforeach; %>
 <% foreach ($columns['indexes'] as $column => $config): %>
 		$table-><%= $indexMethod %>([<%=
-				$this->Migration->stringifyList($config['columns'], ['indent' => 3])
+				$this->Bake->stringifyList($config['columns'], ['indent' => 3])
 				%>], [<%
 				$options = [];
-				echo $this->Migration->stringifyList($config['options'], ['indent' => 3]);
+				echo $this->Bake->stringifyList($config['options'], ['indent' => 3]);
 			%>]);
 <% endforeach; %>
 <% if ($tableMethod === 'create' && !empty($columns['primaryKey'])): %>
 		$table->addPrimaryKey([<%=
-				$this->Migration->stringifyList($columns['primaryKey'], ['indent' => 3])
+				$this->Bake->stringifyList($columns['primaryKey'], ['indent' => 3])
 				%>]);
 <% endif; %>
 <% endif; %>

--- a/src/Template/Bake/config/skeleton.ctp
+++ b/src/Template/Bake/config/skeleton.ctp
@@ -19,61 +19,70 @@ $columnMethod = $this->Migration->columnMethod($action);
 $indexMethod = $this->Migration->indexMethod($action);
 %>
 <?php
+/**
+ * <%= $name %> Migration
+ */
 use Migrations\AbstractMigration;
 
-class <%= $name %> extends AbstractMigration
-{
-    <%- if ($tableMethod === 'create' && !empty($columns['primaryKey'])): %>
+/**
+ * \<%= $name %>
+ */
+class <%= $name %> extends AbstractMigration {
+	<%- if ($tableMethod === 'create' && !empty($columns['primaryKey'])): %>
 
-    public $autoId = false;
+	/**
+	 * Auto ID.
+	 *
+	 * @var bool
+	 */
+	public $autoId = false;
 
-    <%- endif; %>
-    /**
-     * Change Method.
-     *
-     * More information on this method is available here:
-     * http://docs.phinx.org/en/latest/migrations.html#the-change-method
-     * @return void
-     */
-    public function change()
-    {
+	<%- endif; %>
+	/**
+	 * Change Method.
+	 *
+	 * More information on this method is available here:
+	 * http://docs.phinx.org/en/latest/migrations.html#the-change-method
+	 * @return void
+	 */
+	public function change() {
 <% foreach ($tables as $table): %>
-        $table = $this->table('<%= $table%>');
+		$table = $this->table('<%= $table%>');
 <% if ($tableMethod !== 'drop') : %>
 <% if ($columnMethod === 'removeColumn'): %>
 <% foreach ($columns['fields'] as $column => $config): %>
-        <%= "\$table->$columnMethod('" . $column . "');"; %>
+		<%= "\$table->$columnMethod('" . $column . "');"; %>
 <% endforeach; %>
 <% foreach ($columns['indexes'] as $column => $config): %>
-        <%= "\$table->$indexMethod([" . $this->Migration->stringifyList($config['columns']) . ");"; %>
+		<%= "\$table->$indexMethod([" . $this->Migration->stringifyList($config['columns']) . ");"; %>
 <% endforeach; %>
 <% else : %>
 <% foreach ($columns['fields'] as $column => $config): %>
-        $table-><%= $columnMethod %>('<%= $column %>', '<%= $config['columnType'] %>', [<%
-                $columnOptions = $config['options'];
-                $columnOptions = array_intersect_key($columnOptions, $wantedOptions);
-                if (empty($columnOptions['comment'])) {
-                    unset($columnOptions['comment']);
-                }
-                echo $this->Migration->stringifyList($columnOptions, ['indent' => 3]);
-            %>]);
+		$table-><%= $columnMethod %>('<%= $column %>', '<%= $config['columnType'] %>', [<%
+				$columnOptions = $config['options'];
+				$columnOptions = array_intersect_key($columnOptions, $wantedOptions);
+				if (empty($columnOptions['comment'])) {
+					unset($columnOptions['comment']);
+				}
+				echo $this->Migration->stringifyList($columnOptions, ['indent' => 3]);
+			%>]);
 <% endforeach; %>
 <% foreach ($columns['indexes'] as $column => $config): %>
-        $table-><%= $indexMethod %>([<%=
-                $this->Migration->stringifyList($config['columns'], ['indent' => 3])
-                %>], [<%
-                $options = [];
-                echo $this->Migration->stringifyList($config['options'], ['indent' => 3]);
-            %>]);
+		$table-><%= $indexMethod %>([<%=
+				$this->Migration->stringifyList($config['columns'], ['indent' => 3])
+				%>], [<%
+				$options = [];
+				echo $this->Migration->stringifyList($config['options'], ['indent' => 3]);
+			%>]);
 <% endforeach; %>
 <% if ($tableMethod === 'create' && !empty($columns['primaryKey'])): %>
-        $table->addPrimaryKey([<%=
-                $this->Migration->stringifyList($columns['primaryKey'], ['indent' => 3])
-                %>]);
+		$table->addPrimaryKey([<%=
+				$this->Migration->stringifyList($columns['primaryKey'], ['indent' => 3])
+				%>]);
 <% endif; %>
 <% endif; %>
 <% endif; %>
-        $table-><%= $tableMethod %>();
+		$table-><%= $tableMethod %>();
 <% endforeach; %>
-    }
+	}
 }

--- a/src/Template/Bake/config/skeleton.ctp
+++ b/src/Template/Bake/config/skeleton.ctp
@@ -47,7 +47,7 @@ class <%= $name %> extends AbstractMigration {
 	 */
 	public function change() {
 <% foreach ($tables as $table): %>
-		$table = $this->table('<%= $table%>');
+		$table = $this->table('<%= $table%>', ['comment' => '']);
 <% if ($tableMethod !== 'drop') : %>
 <% if ($columnMethod === 'removeColumn'): %>
 <% foreach ($columns['fields'] as $column => $config): %>
@@ -61,6 +61,7 @@ class <%= $name %> extends AbstractMigration {
 		$table-><%= $columnMethod %>('<%= $column %>', '<%= $config['columnType'] %>', [<%
 				$columnOptions = $config['options'];
 				$columnOptions = array_intersect_key($columnOptions, $wantedOptions);
+				$columnOptions['comment'] = '';
 				echo $this->Bake->stringifyList($columnOptions, ['indent' => 3]);
 			%>]);
 <% endforeach; %>
@@ -68,7 +69,6 @@ class <%= $name %> extends AbstractMigration {
 		$table-><%= $indexMethod %>([<%=
 				$this->Bake->stringifyList($config['columns'], ['indent' => 3])
 				%>], [<%
-				$options = [];
 				echo $this->Bake->stringifyList($config['options'], ['indent' => 3]);
 			%>]);
 <% endforeach; %>

--- a/src/Template/Bake/config/snapshot.ctp
+++ b/src/Template/Bake/config/snapshot.ctp
@@ -1,0 +1,57 @@
+<%
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.0.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+
+use Cake\Database\Schema\Table;
+
+$constraints = $foreignKeys = $dropForeignKeys = [];
+$hasUnsignedPk = $this->Migration->hasUnsignedPrimaryKey($tables);
+
+if ($autoId && $hasUnsignedPk) {
+    $autoId = false;
+}
+%>
+<?php
+use Migrations\AbstractMigration;
+
+class <%= $name %> extends AbstractMigration
+{
+    <%- if (!$autoId): %>
+
+    public $autoId = false;
+
+    <%- endif; %>
+    public function up()
+    {
+        <%- echo $this->element('Migrations.create-tables', ['tables' => $tables, 'autoId' => $autoId, 'useSchema' => false]) %>
+    }
+
+    public function down()
+    {
+        <%- foreach ($this->Migration->returnedData['dropForeignKeys'] as $table => $columnsList):
+                $maxKey = count($columnsList) - 1;
+        %>
+        $this->table('<%= $table %>')
+            <%- foreach ($columnsList as $key => $columns): %>
+            ->dropForeignKey(
+                <%= $columns %>
+            )<%= ($key === $maxKey) ? ';' : '' %>
+            <%- endforeach; %>
+
+        <%- endforeach; %>
+        <%- foreach ($tables as $table): %>
+        $this->dropTable('<%= $table%>');
+        <%- endforeach; %>
+    }
+}

--- a/src/Template/Bake/config/snapshot.ctp
+++ b/src/Template/Bake/config/snapshot.ctp
@@ -52,7 +52,7 @@ class <%= $name %> extends AbstractMigration {
 	 * @return void
 	 */
 	public function up() {
-		<%- echo $this->element('Migrations.create-tables', ['tables' => $tables, 'autoId' => $autoId, 'useSchema' => false]) %>
+		<%- echo $this->element('LoadsysTheme.create-tables', ['tables' => $tables, 'autoId' => $autoId, 'useSchema' => false]) %>
 	}
 
 	/**

--- a/src/Template/Bake/config/snapshot.ctp
+++ b/src/Template/Bake/config/snapshot.ctp
@@ -19,39 +19,64 @@ $constraints = $foreignKeys = $dropForeignKeys = [];
 $hasUnsignedPk = $this->Migration->hasUnsignedPrimaryKey($tables);
 
 if ($autoId && $hasUnsignedPk) {
-    $autoId = false;
+	$autoId = false;
 }
 %>
 <?php
+/**
+ * <%= $name %> Migration
+ */
+
 use Migrations\AbstractMigration;
 
-class <%= $name %> extends AbstractMigration
-{
-    <%- if (!$autoId): %>
+/**
+ * \<%= $name %>
+ */
+class <%= $name %> extends AbstractMigration {
+	<%- if (!$autoId): %>
 
-    public $autoId = false;
+	/**
+	 * Auto ID.
+	 *
+	 * @var bool
+	 */
+	public $autoId = false;
 
-    <%- endif; %>
-    public function up()
-    {
-        <%- echo $this->element('Migrations.create-tables', ['tables' => $tables, 'autoId' => $autoId, 'useSchema' => false]) %>
-    }
+	<%- endif; %>
+	/**
+	 * Up Method.
+	 *
+	 * More information on this method is available here:
+	 * http://docs.phinx.org/en/latest/migrations.html#the-up-method
+	 *
+	 * @return void
+	 */
+	public function up() {
+		<%- echo $this->element('Migrations.create-tables', ['tables' => $tables, 'autoId' => $autoId, 'useSchema' => false]) %>
+	}
 
-    public function down()
-    {
-        <%- foreach ($this->Migration->returnedData['dropForeignKeys'] as $table => $columnsList):
-                $maxKey = count($columnsList) - 1;
-        %>
-        $this->table('<%= $table %>')
-            <%- foreach ($columnsList as $key => $columns): %>
-            ->dropForeignKey(
-                <%= $columns %>
-            )<%= ($key === $maxKey) ? ';' : '' %>
-            <%- endforeach; %>
+	/**
+	 * Down Method.
+	 *
+	 * More information on this method is available here:
+	 * http://docs.phinx.org/en/latest/migrations.html#the-down-method
+	 *
+	 * @return void
+	 */
+	public function down() {
+		<%- foreach ($this->Migration->returnedData['dropForeignKeys'] as $table => $columnsList):
+				$maxKey = count($columnsList) - 1;
+		%>
+		$this->table('<%= $table %>')
+			<%- foreach ($columnsList as $key => $columns): %>
+			->dropForeignKey(
+				<%= $columns %>
+			)<%= ($key === $maxKey) ? ';' : '' %>
+			<%- endforeach; %>
 
-        <%- endforeach; %>
-        <%- foreach ($tables as $table): %>
-        $this->dropTable('<%= $table%>');
-        <%- endforeach; %>
-    }
+		<%- endforeach; %>
+		<%- foreach ($tables as $table): %>
+		$this->dropTable('<%= $table%>');
+		<%- endforeach; %>
+	}
 }

--- a/src/Template/Bake/tests/fixture.ctp
+++ b/src/Template/Bake/tests/fixture.ctp
@@ -18,13 +18,15 @@
  */
 %>
 <?php
+/**
+ * <%= $name %> Fixture
+ */
 namespace <%= $namespace %>\Test\Fixture;
 
 use Cake\TestSuite\Fixture\TestFixture;
 
 /**
- * <%= $name %>Fixture
- *
+ * \<%= $namespace %>\Test\Fixture\<%= $name %>Fixture
  */
 class <%= $name %>Fixture extends TestFixture {
 <% if ($table): %>

--- a/src/Template/Bake/tests/test_case.ctp
+++ b/src/Template/Bake/tests/test_case.ctp
@@ -26,6 +26,9 @@ if ($isController) {
 sort($uses);
 %>
 <?php
+/**
+ * Tests for the <%= $fullClassName %> class.
+ */
 namespace <%= $baseNamespace; %>\Test\TestCase\<%= $subNamespace %>;
 
 <% foreach ($uses as $dependency): %>
@@ -33,7 +36,7 @@ use <%= $dependency; %>;
 <% endforeach; %>
 
 /**
- * <%= $fullClassName %> Test Case
+ * <%= $baseNamespace; %>\Test\TestCase\<%= $subNamespace %>\<%= $className %>
  */
 <% if ($isController): %>
 class <%= $className %>Test extends IntegrationTestCase {
@@ -47,7 +50,7 @@ class <%= $className %>Test extends TestCase {
 	 *
 	 * @var array
 	 */
-	public $fixtures = [<%= str_replace('    ', "\t", $this->Bake->stringifyList(array_values($fixtures))) %>];
+	public $fixtures = [<%= $this->Bake->stringifyList(array_values($fixtures)) %>];
 <% endif; %>
 <% if (!empty($construction)): %>
 

--- a/src/View/Helper/BakeHelper.php
+++ b/src/View/Helper/BakeHelper.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Extends the default BakeHelper. Modifies its defaults a bit to serve our
+ * purposes.
+ */
+namespace LoadsysTheme\View\Helper;
+
+use Bake\View\Helper\BakeHelper as BaseBakeHelper;
+
+/**
+ * LoadsysTheme\View\Helper\BakeHelper
+ */
+class BakeHelper extends BaseBakeHelper {
+	/**
+	 * Returns an array converted into a formatted multiline string
+	 *
+	 * This version uses tabs by default, and includes a trailing comma on
+	 * multi-line arrays by default.
+	 *
+	 * @param array $list array of items to be stringified
+	 * @param array $options options to use
+	 * @return string
+	 */
+	public function stringifyList(array $list, array $options = []) {
+		$options += [
+			'indent' => 2,
+			'tab' => "\t",
+			'trailingComma' => true,
+		];
+
+		return parent::stringifyList($list, $options);
+	}
+}

--- a/src/View/Helper/BakeHelper.php
+++ b/src/View/Helper/BakeHelper.php
@@ -14,8 +14,8 @@ class BakeHelper extends BaseBakeHelper {
 	/**
 	 * Returns an array converted into a formatted multiline string
 	 *
-	 * This version uses tabs by default, and includes a trailing comma on
-	 * multi-line arrays by default.
+	 * This version uses tabs by default, and includes a trailing comma (on
+	 * multi-line arrays only) by default.
 	 *
 	 * @param array $list array of items to be stringified
 	 * @param array $options options to use
@@ -25,7 +25,12 @@ class BakeHelper extends BaseBakeHelper {
 		$options += [
 			'indent' => 2,
 			'tab' => "\t",
-			'trailingComma' => true,
+		];
+
+		// MUST be layered in a second pass to pick up the layered [indent]
+		// value from the first pass!
+		$options += [
+			'trailingComma' => ($options['indent'] !== false),
 		];
 
 		return parent::stringifyList($list, $options);

--- a/tests/TestCase/View/Helper/BakeHelperTest.php
+++ b/tests/TestCase/View/Helper/BakeHelperTest.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Tests for the overriden BakeHelper class.
+ */
+namespace LoadsysTheme\Test\TestCase\View\Helper;
+
+use Bake\View\BakeView;
+use LoadsysTheme\View\Helper\BakeHelper;
+use Cake\Network\Request;
+use Cake\TestSuite\Stub\Response;
+use Cake\TestSuite\TestCase;
+
+/**
+ * \LoadsysTheme\Test\TestCase\View\Helper\BakeHelperTest
+ */
+class BakeHelperTest extends TestCase {
+
+	/**
+	 * Fixtures
+	 *
+	 * @var array
+	 */
+	public $fixtures = [];
+
+	/**
+	 * setUp method
+	 *
+	 * @return void
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$request = new Request();
+		$response = new Response();
+		$this->View = new BakeView($request, $response);
+		$this->BakeHelper = new BakeHelper($this->View);
+	}
+
+	/**
+	 * tearDown method
+	 *
+	 * @return void
+	 */
+	public function tearDown() {
+		unset($this->View);
+		unset($this->BakeHelper);
+
+		parent::tearDown();
+	}
+
+	/**
+	 * test stringifyList defaults
+	 *
+	 * @return void
+	 */
+	public function testStringifyListDefaults() {
+		$list = ['one' => 'foo', 'two' => 'bar', 'three'];
+		$result = $this->BakeHelper->stringifyList($list);
+		$spaces = "\t";
+		$expected = "\n" .
+			$spaces . $spaces . "'one' => 'foo',\n" .
+			$spaces . $spaces . "'two' => 'bar',\n" .
+			$spaces . $spaces . "'three',\n" .
+			$spaces;
+		$this->assertSame($expected, $result);
+	}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Set up test environment.
+ */
+
+// @codingStandardsIgnoreFile
+
+use Cake\Core\Plugin;
+
+require_once 'vendor/autoload.php';
+
+define('TMP', sys_get_temp_dir() . DS);
+
+Plugin::load('Bake', [
+	'path' => dirname(dirname(__FILE__)) . DS,
+]);


### PR DESCRIPTION
Integrates corrections for updated sniff rules. Specifically:
- Multi-line arrays should now include a trailing comma by default.
- File and class doc blocks are a bit more consistent (probably still needs work.)
- Migration template files are included, so `bin/cake bake migration --theme LoadsysTheme ...` is now recommended. This will produce files that use tabs, have doc blocks and place open braces on the same line.

This work hasn't been tested yet. I need to coordinate with work in the skeleton to:
1. Integrate this branch of the LoadsysTheme into the skeleton somehow.
2. Bake a project from the skeleton "in-progress".
3. Bake example migrations and code in the spawned project.
4. Run the code-sniffer and unit tests on the resulting baked code.

Also, it would be cool if there was a way to make the default BakeShell someone "know" to use `--theme LoadsysTheme` "by default" without it having to be specified. Seems like this _should_ be possible, but it requires investigation. I'd like to do this via an Event hook or Configure so it can be done (and customized) on a per-project basis, instead of depending on a wrapper bash script.
